### PR TITLE
Fixed step two description of how to section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Follow [Anil Chandra Naidu Matcha](https://twitter.com/matchaman11) & [Ankur Sin
    ```
 
    ```shell
-   python privateGPT.
+   python privateGPT.py
    ```
 
 3. Open <http://localhost:3000>, click on download model to download the required model initially


### PR DESCRIPTION
Originally it said just "python privateGPT." which generates "No such file or directory" error, and replaced with "python privateGPT.py" which works.